### PR TITLE
Fix listring item loss

### DIFF
--- a/modifier.lua
+++ b/modifier.lua
@@ -129,6 +129,15 @@ local function get_real_count(instack,new_stack,stack)
 	return stack:get_count()
 end
 
+local function return_items(stack,player)
+	local inv = player:get_inventory()
+
+	local excess = inv:add_item("main",stack)
+	if excess and not excess:is_empty() then
+		minetest.item_drop(excess,player,player:get_pos())
+	end
+end
+
 minetest.register_node("node_texture_modifier:node_texture_modifier", {
 	description = "Node Texture Modifier",
 	tiles = {"node_texture_modifier_node_texture_modifier.png", "node_texture_modifier_node_texture_modifier.png",
@@ -162,14 +171,21 @@ minetest.register_node("node_texture_modifier:node_texture_modifier", {
 	on_metadata_inventory_put = function(pos)
 		update_formspec(pos)
 	end,
-	on_metadata_inventory_take = function(pos, listname, index, stack)
+	on_metadata_inventory_take = function(pos, listname, index, stack, player)
 		if listname=="out" then
 			local meta = minetest.get_meta(pos)
 			local inv = meta:get_inventory()
+
 			local instack = inv:get_stack("in", 1)
 			local new_stack = inv:get_stack("out",index)
 			local count = get_real_count(instack,new_stack,stack)
 			local newcount = instack:get_count()-count
+
+			-- Return items if a right-click swap has happened
+			if new_stack:get_name() ~= stack:get_name() then
+				return_items(new_stack,player)
+			end
+
 			inv:set_stack("in", 1, instack:get_name().." "..newcount )
 		end
 		update_formspec(pos, stack)

--- a/modifier.lua
+++ b/modifier.lua
@@ -134,7 +134,7 @@ local function return_items(stack,player)
 
 	local excess = inv:add_item("main",stack)
 	if excess and not excess:is_empty() then
-		minetest.item_drop(excess,player,player:get_pos())
+		minetest.item_drop(excess,player,player:getpos())
 	end
 end
 

--- a/modifier.lua
+++ b/modifier.lua
@@ -117,6 +117,18 @@ local function update_formspec(pos)
 	
 end
 
+local function get_real_count(instack,new_stack,stack)
+	if not new_stack:is_empty() then
+		if new_stack:get_name() ~= stack:get_name() then
+			return instack:get_count()
+		elseif new_stack:get_count() + stack:get_count() > stack:get_stack_max() then
+			return stack:get_count() - new_stack:get_count()
+		end
+	end
+
+	return stack:get_count()
+end
+
 minetest.register_node("node_texture_modifier:node_texture_modifier", {
 	description = "Node Texture Modifier",
 	tiles = {"node_texture_modifier_node_texture_modifier.png", "node_texture_modifier_node_texture_modifier.png",
@@ -155,7 +167,9 @@ minetest.register_node("node_texture_modifier:node_texture_modifier", {
 			local meta = minetest.get_meta(pos)
 			local inv = meta:get_inventory()
 			local instack = inv:get_stack("in", 1)
-			local newcount = instack:get_count()-stack:get_count()
+			local new_stack = inv:get_stack("out",index)
+			local count = get_real_count(instack,new_stack,stack)
+			local newcount = instack:get_count()-count
 			inv:set_stack("in", 1, instack:get_name().." "..newcount )
 		end
 		update_formspec(pos, stack)

--- a/modifier.lua
+++ b/modifier.lua
@@ -119,7 +119,8 @@ end
 
 local function get_real_count(instack,new_stack,stack)
 	if not new_stack:is_empty() then
-		if new_stack:get_name() ~= stack:get_name() then
+		if new_stack:get_name() ~= stack:get_name() 
+		or new_stack:get_count() == new_stack:get_stack_max() then
 			return instack:get_count()
 		elseif new_stack:get_count() + stack:get_count() > stack:get_stack_max() then
 			return stack:get_count() - new_stack:get_count()
@@ -182,7 +183,8 @@ minetest.register_node("node_texture_modifier:node_texture_modifier", {
 			local newcount = instack:get_count()-count
 
 			-- Return items if a right-click swap has happened
-			if new_stack:get_name() ~= stack:get_name() then
+			if new_stack:get_name() ~= stack:get_name()
+			or new_stack:get_count() == new_stack:get_stack_max() then
 				return_items(new_stack,player)
 			end
 


### PR DESCRIPTION
Fixes #2 and a partial fix for #3 
#3 Is now an item loss bug, where swapped items are deleted when the inventory updates.

--EDIT
#3 should now be fixed as of 9e988d5
